### PR TITLE
32x32 grid fixes

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -79,7 +79,7 @@ Also drop me a line and let me know how you end up using the addon.
 <code>
     ofBackground(0);
    
-    ring24px.drawGrabRegion(hide);
+    ring24px.drawGrabRegion(true);
 
     ring24px.drawRing(50, 50);
 </code>

--- a/src/NeoPixelGrid32x32.cpp
+++ b/src/NeoPixelGrid32x32.cpp
@@ -25,14 +25,14 @@ void NeoPixelGrid32x32::setupLedGrid()
     
     for (int i = 0; i < size; i++)
     {
-            for (int row = 0; row < 32; row++)
+        for (int row = 0; row < 32; row++)
+        {
+            if((i >= (row*32))&&(i <= ((row*32)+31)))
             {
-                if((i >= (row*32))&&(i <= ((row*32)+31)))
-                {
-                    rx = x+((i-(row*32))*spacing);
-                    ry = y+(spacing*row);
-                }
+                rx = x+((i-(row*32))*spacing);
+                ry = y+(spacing*row);
             }
+        }
         pos.push_back(ofVec2f(rx,ry));
     }
 }
@@ -63,7 +63,7 @@ void NeoPixelGrid32x32::grabImageData(ofPoint grabPos)
     // Change Capture Location
     _pos = grabPos;
     img.clear();
-    img.grabScreen(_pos.x-x,_pos.y-y,230,230);
+    img.grabScreen(_pos.x+(x*2),_pos.y+(y*2),230,230);
     
     //Update the position of the Grid
     for (int i = 0; i < pos.size(); i++)
@@ -81,7 +81,7 @@ void NeoPixelGrid32x32::drawGrabRegion(bool hideArea)
         ofNoFill();
         ofSetLineWidth(2);
         ofSetColor(255, 255);
-        ofRect(_pos.x-7,_pos.y-6,230,234);
+        ofRect(_pos.x,_pos.y,230,230);
         ofPopStyle();
         
         // Visualise the Grabber
@@ -95,11 +95,9 @@ void NeoPixelGrid32x32::drawGrabRegion(bool hideArea)
         ofNoFill();
     }
     
-    ofRect(_pos.x-5, _pos.y-4,230,224);
-    
     for (int i = 0; i < pos.size(); i++)
     {
-        ofCircle(pos[i]+ofVec2f(_pos.x-x, _pos.y-y),2);
+        ofCircle(pos[i]+ofVec2f(_pos.x+(x*2), _pos.y+(y*2)),2);
     }
 }
 //--------------------------------------------------------------

--- a/src/ofxOPC.cpp
+++ b/src/ofxOPC.cpp
@@ -105,7 +105,7 @@ void ofxOPC::writeChannel(uint8_t channel, vector<ofColor>pix)
     uint16_t channel_offset = (channel - 1) * 64;
     
     // Copy the data
-    for (int i = 0; i < pix.size(); i++)
+    for (unsigned int i = 0; i < pix.size(); i++)
     {
         OPC_SPC_packet_data[channel_offset + i].r = pix[i].r;
         OPC_SPC_packet_data[channel_offset + i].g = pix[i].g;
@@ -134,7 +134,7 @@ void ofxOPC::writeChannel(uint8_t channel, vector <ofColor> pix1,vector <ofColor
     uint16_t channel_offset = (channel - 1) * 64;
     
     // Copy the data
-    for (int i = 0; i < pix1.size(); i++)
+    for (unsigned int i = 0; i < pix1.size(); i++)
     {
         OPC_SPC_packet_data[channel_offset + i].r = pix1[i].r;
         OPC_SPC_packet_data[channel_offset + i].g = pix1[i].g;


### PR DESCRIPTION
I noticed there was some slight inaccuracy in the positioning of the grab region (I'm trying to use a canvas no bigger than the size of the grab region, for various reasons). Also a small fix that helps compiling errors I encountered on rPi (model 1 B+)

Tested on rPi and OSX
